### PR TITLE
default value with a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ const default_values = require('metalsmith-default-values');
   {
     pattern : 'posts/*.md',
     defaults: {
-      layout: 'post.hbs'
+      layout: 'post.hbs',
+      date: function (post) {
+        return post.stats.ctime;
+      }
     }
   },
   {

--- a/lib/set_defaults.js
+++ b/lib/set_defaults.js
@@ -16,6 +16,7 @@ const set_defaults = defaults => item => {
   debug('defaults: %o', defaults);
   Object.keys(defaults).forEach(key => {
     const value = get(item, key);
+    const default_value = defaults[key];
 
     // For more verbose debugging enable the following
     // debug('key: %s', key);
@@ -23,7 +24,11 @@ const set_defaults = defaults => item => {
     // debug('value: %s', value);
 
     if (value === void 0 || value === null) {
-      set(item, key, defaults[key]);
+      if (typeof default_value === 'function') {
+        set(item, key, default_value(item));
+      } else {
+        set(item, key, default_value);
+      }
     }
   });
   return item;


### PR DESCRIPTION
Dear maintainers

Thank you for your nice project.

I propose that default values given with a function.
This modification is useful to refer other meta values such as:

```
  .use(default_values([
    {
      pattern: 'posts/*.md',
      defaults: {
        layout: 'post.hbs',
        date: function (post) {
          return post.stats.ctime;
        }
      }
    }
  ]))
```
Best regards,